### PR TITLE
Update preferences.css

### DIFF
--- a/whitefox/browser/preferences/in-content/preferences.css
+++ b/whitefox/browser/preferences/in-content/preferences.css
@@ -22,6 +22,32 @@ treecol {
   -moz-user-select: none;
 }
 
+#engineList treechildren::-moz-tree-image(engineShown, checked),
+#blocklistsTree treechildren::-moz-tree-image(selectionCol, checked) {
+  list-style-image: url("chrome://global/skin/in-content/check.svg#check");
+  width: 21px;
+  height: 21px;
+}
+
+#engineList treechildren::-moz-tree-image(engineShown, checked, selected),
+#blocklistsTree treechildren::-moz-tree-image(selectionCol, checked, selected) {
+  list-style-image: url("chrome://global/skin/in-content/check.svg#check-inverted");
+}
+
+#engineList treechildren::-moz-tree-row,
+#blocklistsTree treechildren::-moz-tree-row {
+  min-height: 36px;
+}
+
+#blocklistsTree treechildren::-moz-tree-cell-text{
+  -moz-margin-start: 7px;
+}
+
+#selectionCol {
+  min-width: 26px;
+  max-width: 26px;
+}
+
 /* Category List */
 
 .category-icon {


### PR DESCRIPTION
This is to address issue #2 in @lychichem's fork.  This change probably should be matched with removing the corresponding code from search.css in the same folder (after some checking).  The code came form the newer Nighly 43.0a1 and has some small additions to make the columns align better (yet not perfectly!).